### PR TITLE
Changed 'main' to 'develop' in static_dev.yml

### DIFF
--- a/.github/workflows/static_dev.yml
+++ b/.github/workflows/static_dev.yml
@@ -4,7 +4,7 @@ name: Deploy static content to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: ["main"]
+    branches: ["develop"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
This pull request makes a small configuration change to the GitHub Actions workflow for deploying static content. The workflow will now run on pushes to the `develop` branch instead of the `main` branch.