### PR TITLE
Updated apiClient to use the actuall API url

### DIFF
--- a/smm_agency_site/assets/js/apiClient.js
+++ b/smm_agency_site/assets/js/apiClient.js
@@ -3,7 +3,7 @@
 
 import { updateContent, getContent } from "./i18n.js";
 
-const BASE = window.API_BASE_URL || ""; // e.g., "http://localhost:8080"
+const BASE = window.API_BASE_URL || "http://sparkagencyllc.com/sparkagency"; // e.g., "http://localhost:8080"
 
 async function safeJson(resp) {
   if (!resp.ok) throw new Error(`${resp.status}`);


### PR DESCRIPTION
This pull request updates the default API base URL used in the client-side code to ensure requests are directed to the correct backend endpoint.

Configuration update:

* Changed the default value of `BASE` in `apiClient.js` to `"http://sparkagencyllc.com/sparkagency"` when `window.API_BASE_URL` is not set, improving reliability in production environments.